### PR TITLE
Basic changes for gcc use for compilation

### DIFF
--- a/config.linux.mk
+++ b/config.linux.mk
@@ -117,7 +117,7 @@ else
 	CXX_RAW = g++ 
 	CC = ${CC_RAW}
 	CXX = ${CXX_RAW}
-	LD = ld
+	LD = gcc    # ld
 	OBJDUMP = objdump
 	#if we are NOT using the atx.x stuff, prepend nothing.
         RPATH_PREPEND =

--- a/config.mk
+++ b/config.mk
@@ -23,14 +23,61 @@
 #
 # IBM_PROLOG_END_TAG
 
-#select a default target architecture
-#if no target arch is set, select PPC64BE for convenience.
+# Select default values if not set
+# using customrc.p8elblkkermc config file
+#-----------------------------------------
+# export MAKECMD=make
+# export CUSTOMFLAGS="-mcpu=power8 -mtune=power8"
+# export BLOCK_FILEMODE_ENABLED=0
+# export BLOCK_MC_ENABLED=1
+# export BLOCK_KERNEL_MC_ENABLED=1
+# export TARGET_PLATFORM="PPC64EL"
+#-----------------------------------------
+#if no target arch is set, select current platform for convenience.
 ifndef TARGET_PLATFORM
-    TARGET_PLATFORM=PPC64BE
+    UNAME=$(shell uname -m)
+    ifeq ( $(UNAME),ppc64le)
+       TARGET_PLATFORM=PPC64EL
+    else
+       TARGET_PLATFORM=PPC64BE
+    endif
 endif
 #If the target architecture is set, pass an architecture
 #down as a #define to the underlying code
-ARCHFLAGS += -DTARGET_ARCH_${TARGET_PLATFORM}
+export ARCHFLAGS += -DTARGET_ARCH_${TARGET_PLATFORM}
+
+# ADV_TOOLCHAIN_PATH
+AT71PATH=/opt/at7.1
+AT90PATH=/opt/at9.0-2-rc2
+ifneq ($(AT71PATH),)
+    export ADV_TOOLCHAIN_PATH=$AT71PATH
+else
+ export ADV_TOOLCHAIN_PATH=$AT90PATH
+endif
+ifeq ( $(ADV_TOOLCHAIN_PATH),)
+    USE_ADVANCED_TOOLCHAIN=no
+endif
+
+ifeq ( $(USE_ADVANCED_TOOLCHAIN),yes)
+   export CUSTOMFLAGS="-mcpu=power8 -mtune=power8"
+   export PATH=${ADV_TOOLCHAIN_PATH}/bin:${ADV_TOOLCHAIN_PATH}/sbin:${PATH}
+else
+   USE_ADVANCED_TOOLCHAIN=no
+   export CUSTOMFLAGS="-mcpu=power8"
+endif
+
+#
+ifndef BLOCK_FILEMODE_ENABLED
+   export BLOCK_FILEMODE_ENABLED=0
+endif
+
+ifndef BLOCK_MC_ENABLED
+   export BLOCK_MC_ENABLED=1
+endif
+
+ifndef BLOCK_KERNEL_MC_ENABLED
+   export BLOCK_KERNEL_MC_ENABLED=1
+endif
 
 #Determine if this a linux or AIX system
 

--- a/src/block/test/blk_api_tst.c
+++ b/src/block/test/blk_api_tst.c
@@ -468,7 +468,7 @@ int blk_fvt_alloc_list_io_bufs(int size)
     bzero(blk_fvt_comp_data_buf,BLK_FVT_BUFSIZE*size);
     /* fill compare buffer with pattern */
     fd = open ("/dev/urandom", O_RDONLY);
-    read (fd, blk_fvt_comp_data_buf, BLK_FVT_BUFSIZE*size);
+    ret = read (fd, blk_fvt_comp_data_buf, BLK_FVT_BUFSIZE*size);
     close (fd);
     return(0);
 }
@@ -646,7 +646,7 @@ blk_fvt_intrp_io_tst(chunk_id_t id,
 
     /* fill compare buffer with pattern */
     fd = open("/dev/urandom", O_RDONLY);
-    read(fd, blk_fvt_comp_data_buf, BLK_FVT_BUFSIZE);
+    rc = read(fd, blk_fvt_comp_data_buf, BLK_FVT_BUFSIZE);
     close(fd);
 
     // testflag 1 - NO_INTRP      set, null status,  io_flags ARW_USER  set
@@ -893,7 +893,7 @@ void *blk_io_loop(void *data)
                     }
 
                     fd = open ("/dev/urandom", O_RDONLY);
-                    read (fd, comp_data_buf, BLK_FVT_BUFSIZE);
+                    rc = read (fd, comp_data_buf, BLK_FVT_BUFSIZE);
                     close (fd);
 
                     rc = cblk_write(blk_data->chunk_id[x],comp_data_buf,blk_number,1,0);
@@ -973,7 +973,7 @@ void *blk_io_loop(void *data)
                     }
 
                     fd = open ("/dev/urandom", O_RDONLY);
-                    read (fd, comp_data_buf, BLK_FVT_BUFSIZE);
+                    rc = read (fd, comp_data_buf, BLK_FVT_BUFSIZE);
                     close (fd);
 
                     rc = cblk_awrite(blk_data->chunk_id[x],comp_data_buf,blk_number,1,&tag,NULL,0);
@@ -1249,7 +1249,7 @@ void blocking_io_tst (chunk_id_t id, int *ret, int *err)
     for (i=0; i < 1000; i++,lba++) {
         /* fill compare buffer with pattern */
         fd = open ("/dev/urandom", O_RDONLY);
-        read (fd, blk_fvt_comp_data_buf, BLK_FVT_BUFSIZE);
+        rc = read (fd, blk_fvt_comp_data_buf, BLK_FVT_BUFSIZE);
         close (fd);
         rc = cblk_awrite(id,blk_fvt_comp_data_buf,lba,nblocks,&cmdtag[i],NULL,arflg);
         DEBUG_3("\n***** cblk_awrite rc = 0x%d, tag = %d, lba =0x%lx\n",rc, cmdtag[i], lba);
@@ -1465,7 +1465,7 @@ void io_perf_tst (chunk_id_t id, int *ret, int *err)
 
     /* fill compare buffer with pattern */
     fd = open ("/dev/urandom", O_RDONLY);
-    read (fd, blk_fvt_comp_data_buf, BLK_FVT_BUFSIZE*num_cmds);
+    rc = read (fd, blk_fvt_comp_data_buf, BLK_FVT_BUFSIZE*num_cmds);
     close (fd);
 
     for (x=0; x<loops ; x++, y++) {
@@ -1627,7 +1627,7 @@ int max_context(int *ret, int *err, int reqs, int cntx, int flags, int mode)
                 DEBUG_1("\nmax_context: Child = %d, OPENED \n", i+1 );
                 close_now = 0;
                 while ( !close_now) {
-                    read(pipefds[i*2], &close_now, sizeof(int));
+                    status = read(pipefds[i*2], &close_now, sizeof(int));
                     DEBUG_2("\nChild %d, Received %d \n",pid, close_now);
                 }
                 DEBUG_2("\nChild %d, Received Parent's OK =%d \n",pid, close_now);
@@ -1639,8 +1639,8 @@ int max_context(int *ret, int *err, int reqs, int cntx, int flags, int mode)
                 child_ret = j;
                 child_err = errno;
                 /* Send errcode thru ouput side */
-                write(fds[(i*2)+1],&child_ret, sizeof(int));
-                write(fds[(i*2)+1],&child_err, sizeof(int));
+                status = write(fds[(i*2)+1],&child_ret, sizeof(int));
+                status = write(fds[(i*2)+1],&child_err, sizeof(int));
 
                 /* exit error */
                 exit(1);
@@ -1652,7 +1652,7 @@ int max_context(int *ret, int *err, int reqs, int cntx, int flags, int mode)
     sleep (5);        
     for (i = 0; i < cntx; i++) {
         ok_to_close = 1;
-        write(pipefds[(i*2)+1], &ok_to_close, sizeof(int));
+        status = write(pipefds[(i*2)+1], &ok_to_close, sizeof(int));
         DEBUG_1("\nparent sends ok_to_close to %d \n",i+1);
     }
     ret_code = errcode = 0;
@@ -1670,8 +1670,8 @@ int max_context(int *ret, int *err, int reqs, int cntx, int flags, int mode)
                 if (WIFEXITED(status)) {
                     DEBUG_2("child =%d, status 0x%x \n",i,status);
                     if (WEXITSTATUS(status)) { 
-                        read(fds[(i*2)], &ret_code, sizeof(ret_code));
-                        read(fds[(i*2)], &errcode, sizeof(errcode));
+                        status = read(fds[(i*2)], &ret_code, sizeof(ret_code));
+                        status = read(fds[(i*2)], &errcode, sizeof(errcode));
                         DEBUG_3("\nchild %d errcode %d, ret_code %d\n",
                                 i, errcode, ret_code);
                     } else {
@@ -1768,7 +1768,7 @@ int fork_and_clone_mode_test(int *ret, int *err, int pmode, int cmode)
 
 
     // create pipe to be used by child  to pass back status
-    pipe(fd);
+    rc = pipe(fd);
 
     if (blk_fvt_setup(1) < 0)
         return (-1);
@@ -1808,8 +1808,8 @@ int fork_and_clone_mode_test(int *ret, int *err, int pmode, int cmode)
             child_ret = rc;
             child_err = errno;
             /* Send errcode thru ouput side */
-            write(fd[1],&child_ret, sizeof(int));
-            write(fd[1],&child_err, sizeof(int));
+            rc = write(fd[1],&child_ret, sizeof(int));
+            rc = write(fd[1],&child_err, sizeof(int));
             DEBUG_1("Sending child_ret %d\n",child_ret);
             cblk_close(id,0);
             exit (1);
@@ -1835,10 +1835,10 @@ int fork_and_clone_mode_test(int *ret, int *err, int pmode, int cmode)
                 if (WIFEXITED(child_status)) {
                     DEBUG_2("child =%d, child_status 0x%x \n",child_pid,child_status);
                     if (WEXITSTATUS(child_status)) { 
-                        read(fd[0], &ret_code, sizeof(ret_code));
+                        rc = read(fd[0], &ret_code, sizeof(ret_code));
                         DEBUG_2("\nchild %d retcode %d\n",
                                 child_pid, ret_code);
-                        read(fd[0], &errcode, sizeof(errcode));
+                        rc = read(fd[0], &errcode, sizeof(errcode));
                         DEBUG_2("\nchild %d errcode %d\n",
                                 child_pid, errcode);
                     } else {
@@ -1898,7 +1898,7 @@ int fork_and_clone(int *ret, int *err, int mode)
 
     // create pipe to be used by child  to pass back status
 
-    pipe(fd);
+    rc = pipe(fd);
 
     if (blk_fvt_setup(1) < 0)
         return (-1);
@@ -1952,8 +1952,8 @@ int fork_and_clone(int *ret, int *err, int mode)
             child_ret = rc;
             child_err = errno;
             /* Send errcode thru ouput side */
-            write(fd[1],&child_ret, sizeof(int));
-            write(fd[1],&child_err, sizeof(int));
+            rc = write(fd[1],&child_ret, sizeof(int));
+            rc = write(fd[1],&child_err, sizeof(int));
             DEBUG_2("Sending child ret=%d, err=%d\n",child_ret, child_err);
             cblk_close(id,0);
             exit (1);
@@ -1969,8 +1969,8 @@ int fork_and_clone(int *ret, int *err, int mode)
             child_ret = rc;
             child_err = errno;
             /* Send errcode thru ouput side */
-            write(fd[1],&child_ret, sizeof(int));
-            write(fd[1],&child_err, sizeof(int));
+            rc = write(fd[1],&child_ret, sizeof(int));
+            rc = write(fd[1],&child_err, sizeof(int));
             DEBUG_2("Sending child ret=%d, err=%d\n",child_ret, child_err);
             cblk_close(id,0);
             exit (1);
@@ -1982,8 +1982,8 @@ int fork_and_clone(int *ret, int *err, int mode)
             child_ret = rc;
             child_err = errno;
             /* Send errcode thru ouput side */
-            write(fd[1],&child_ret, sizeof(int));
-            write(fd[1],&child_err, sizeof(int));
+            rc = write(fd[1],&child_ret, sizeof(int));
+            rc = write(fd[1],&child_err, sizeof(int));
             DEBUG_2("Sending child ret=%d, err=%d\n",child_ret, child_err);
             cblk_close(id,0);
             exit (1);

--- a/src/block/test/fvt_block.C
+++ b/src/block/test/fvt_block.C
@@ -1598,38 +1598,38 @@ TEST(Block_FVT_Suite, BLK_API_FVT_FM_1M_xfersize_physical)
     if (lun_sz < nblks)
         nblks = lun_sz;
 
-        xfersz = nblks;
-        cmd = FV_WRITE;
-        lba = 1;
+    xfersz = nblks;
+    cmd = FV_WRITE;
+    lba = 1;
 
-        blk_fvt_io(id, cmd, lba, xfersz, &ret, &er_no, io_flags, open_flags); 
+    blk_fvt_io(id, cmd, lba, xfersz, &ret, &er_no, io_flags, open_flags); 
     
-        EXPECT_EQ(xfersz, (size_t)ret);
-        if ((int)xfersz != ret) {
+    EXPECT_EQ(xfersz, (size_t)ret);
+    if ((int)xfersz != ret) {
            fprintf(stderr,"Write failed 1M xfersz \n");
            blk_open_tst_cleanup();
            return;
-        }
+    }
 
-        cmd = FV_READ;
-        lba = 1;
-        // read what was wrote  xfersize
-        blk_fvt_io(id, cmd, lba, xfersz, &ret, &er_no, io_flags, open_flags); 
+    cmd = FV_READ;
+    lba = 1;
+    // read what was wrote  xfersize
+    blk_fvt_io(id, cmd, lba, xfersz, &ret, &er_no, io_flags, open_flags); 
 
-        EXPECT_EQ(xfersz, (size_t)ret);
-        if ((int)xfersz != ret) {
+    EXPECT_EQ(xfersz, (size_t)ret);
+    if ((int)xfersz != ret) {
            fprintf(stderr,"Read failed 1M xfersz \n");
            blk_open_tst_cleanup();
            return;
-        }
-        // compare buffers
+    }
+    // compare buffers
     
-        blk_fvt_cmp_buf(xfersz, &ret);
-        if (ret != 0) {
+    blk_fvt_cmp_buf(xfersz, &ret);
+    if (ret != 0) {
            fprintf(stderr,"Compare failed 1M xfersz \n");
            blk_open_tst_cleanup();
-        }
-        ASSERT_EQ(0, ret);
+    }
+    ASSERT_EQ(0, ret);
 
     blk_open_tst_cleanup();
 }
@@ -1692,38 +1692,38 @@ TEST(Block_FVT_Suite, BLK_API_FVT_FM_phys_lun_large_xfer_test)
     if (lun_sz < nblks)
         nblks = lun_sz;
 
-        xfersz = nblks;
-        cmd = FV_WRITE;
-        lba = 1;
-
-        blk_fvt_io(id, cmd, lba, xfersz, &ret, &er_no, io_flags, open_flags); 
+    xfersz = nblks;
+    cmd = FV_WRITE;
+    lba = 1;
     
-        EXPECT_EQ(xfersz, (size_t)ret);
-        if ((int)xfersz != ret) {
-           fprintf(stderr,"Write failed 1M+ xfersz \n");
-           blk_open_tst_cleanup();
-           return;
-        }
-
-        cmd = FV_READ;
-        lba = 1;
-        // read what was wrote  xfersize
-        blk_fvt_io(id, cmd, lba, xfersz, &ret, &er_no, io_flags, open_flags); 
-
-        EXPECT_EQ(xfersz, (size_t)ret);
-        if ((int)xfersz != ret) {
-           fprintf(stderr,"Read failed 1M+ xfersz \n");
-           blk_open_tst_cleanup();
-           return;
-        }
-        // compare buffers
+    blk_fvt_io(id, cmd, lba, xfersz, &ret, &er_no, io_flags, open_flags); 
     
-        blk_fvt_cmp_buf(xfersz, &ret);
-        if (ret != 0) {
-           fprintf(stderr,"Compare failed 1M+ xfersz \n");
-           blk_open_tst_cleanup();
-        }
-        ASSERT_EQ(0, ret);
+    EXPECT_EQ(xfersz, (size_t)ret);
+    if ((int)xfersz != ret) {
+       fprintf(stderr,"Write failed 1M+ xfersz \n");
+       blk_open_tst_cleanup();
+       return;
+    }
+    
+    cmd = FV_READ;
+    lba = 1;
+    // read what was wrote  xfersize
+    blk_fvt_io(id, cmd, lba, xfersz, &ret, &er_no, io_flags, open_flags); 
+    
+    EXPECT_EQ(xfersz, (size_t)ret);
+    if ((int)xfersz != ret) {
+       fprintf(stderr,"Read failed 1M+ xfersz \n");
+       blk_open_tst_cleanup();
+       return;
+    }
+    // compare buffers
+    
+    blk_fvt_cmp_buf(xfersz, &ret);
+    if (ret != 0) {
+       fprintf(stderr,"Compare failed 1M+ xfersz \n");
+       blk_open_tst_cleanup();
+    }
+    ASSERT_EQ(0, ret);
 
     blk_open_tst_cleanup();
 }

--- a/src/cflash/test/174.c
+++ b/src/cflash/test/174.c
@@ -35,7 +35,7 @@ int test_traditional_IO( int flag, int disk_num )
 {
 
 
-    int rc;
+    int rc, rc2;
     struct ctx myctx[20];
     struct ctx *p_ctx[20];
     char *disk_name,*disk_name1,temp[MC_PATHLEN], *str=NULL;
@@ -106,7 +106,9 @@ int test_traditional_IO( int flag, int disk_num )
                 }
             }
             sprintf(str, "cfgmgr -l %s ", disk_name);
-            system(str);
+            rc2=system(str);
+	    if ( rc2 )
+		printf("%s failed\n",str);
             // Wait for IO thread to complete
             break;
 
@@ -149,7 +151,7 @@ int test_traditional_IO( int flag, int disk_num )
                 }
             }
             sprintf(str, "cfgmgr -l %s ", disk_name);
-            system(str);
+            rc2=system(str);
 
             break;
 
@@ -237,10 +239,10 @@ int test_traditional_IO( int flag, int disk_num )
             else rc=0;
             close(p_ctx[i]->fd);
 
-            system("varyonvg NEW_VG; lspv");
-            system("varyoffvg NEW_VG; exportvg NEW_VG");
+            rc2=system("varyonvg NEW_VG; lspv");
+            rc2=system("varyoffvg NEW_VG; exportvg NEW_VG");
             sprintf(str, "chdev -l %s -a pv=clear", disk_name);
-            system(str);
+            rc2=system(str);
 
             return rc;
             //7.1.187
@@ -323,7 +325,7 @@ int test_traditional_IO( int flag, int disk_num )
             // disabling disk 1
             // changing reserve policy to no_reserve
             sprintf(str," chdev -l %s -a reserve_policy=no_reserve", disk_name);
-            system(str);
+            rc2=system(str);
             sprintf(str, "chpath -s disable -l %s -i 0", disk_name);
             rc=system(str);
 
@@ -353,7 +355,7 @@ int test_traditional_IO( int flag, int disk_num )
                 }
             }
             sprintf(str, "chpath -s enable -l %s -i 0", disk_name);
-            system(str);
+            rc2=system(str);
 
             return rc;
             //7.1.214

--- a/src/cflash/test/cflash_test2.c
+++ b/src/cflash/test/cflash_test2.c
@@ -694,7 +694,7 @@ int mc_size_regress_internal()
         CHECK_RC(rc, "mc_size");
         if ( i % 10 == 0)
         {
-            system("date");
+            rc = system("date");
             printf("%d: loop %d(%d) done...\n", pid, i, mc_size_regrss_l);
         }
         fflush(stdout);
@@ -721,7 +721,7 @@ int mc_test_chunk_regress(int cmd)
     char *str = getenv("LONG_RUN");
     if (str != NULL)
     {
-        system("date");
+        rc = system("date");
         printf("%d: Do %s Regress for %d context processes\n",
                pid, __func__, max_p);
         if (4 == cmd)
@@ -760,7 +760,7 @@ int mc_test_chunk_regress(int cmd)
 
 int mc_test_chunk_regress_long()
 {
-    int rc;
+    int rc, rc2;
     int i;
     int lrun=1;
     char *str = getenv("LONG_RUN");
@@ -780,7 +780,9 @@ int mc_test_chunk_regress_long()
         debug("Loop %d(%d) done...\n", i, lrun);
         if (i%10 == 0)
         {
-            system("date");
+            rc2 = system("date");
+            if (rc2)
+		printf("Invalid date\n");
             printf("Loop %d(%d) done...\n", i, lrun);
             fflush(stdout);
         }
@@ -1030,7 +1032,7 @@ int mc_test_ctx_regress(int cmd)
 
 int test_mc_regress_ctx_crt_dstr(int cmd)
 {
-    int rc;
+    int rc, rc2;
     int i;
     int lrun=1;
     char *str = getenv("LONG_RUN");
@@ -1040,7 +1042,7 @@ int test_mc_regress_ctx_crt_dstr(int cmd)
         lrun = 400; //for 4 Hrs
         if (3 == cmd)
             lrun = 100;
-        system("date");
+        rc2 = system("date");
         printf("%s : %d : Regress loop : %d\n", __func__, __LINE__, lrun);
         fflush(stdout);
     }
@@ -1055,7 +1057,9 @@ int test_mc_regress_ctx_crt_dstr(int cmd)
         debug("Loop %d(%d) done...\n", i, lrun);
         if (i%10 == 0)
         {
-            system("date");
+            rc2 = system("date");
+	    if ( rc2 )
+		printf("Invalid date\n");
             printf("%d: Loop %d(%d) done...\n", getpid(), i, lrun);
             fflush(stdout);
         }

--- a/src/cflash/test/cflash_test_engine.c
+++ b/src/cflash/test/cflash_test_engine.c
@@ -31,7 +31,7 @@ int test1()
 
 int mc_test_engine(mc_test_t test_name)
 {
-    int rc = 0;
+    int rc = 0, rc2;
     if (get_fvt_dev_env()) return -1;
 #ifdef _AIX
     //system("ctctrl -c cflashdd -r  memtraceoff");
@@ -40,15 +40,15 @@ int mc_test_engine(mc_test_t test_name)
         system("ctctrl -c cflashdd -r  -q");
 #else
     if (DEBUG)
-        system("echo \"module cxlflash +p\" > /sys/kernel/debug/dynamic_debug/control");
+        rc = system("echo \"module cxlflash +p\" > /sys/kernel/debug/dynamic_debug/control");
     displayBuildinfo();
 #endif
 
     if (DEBUG)
     {
-        system("echo;echo ---------------------- Test Start Timestamp ----------------------");
-        system("date");
-        system("echo ------------------------------------------------------------------; echo");
+        rc = system("echo;echo ---------------------- Test Start Timestamp ----------------------");
+        rc = system("date");
+        rc = system("echo ------------------------------------------------------------------; echo");
     }
 
     if (fork() == 0)
@@ -798,9 +798,11 @@ int mc_test_engine(mc_test_t test_name)
 
     if (DEBUG)
     {
-        system("echo;echo ---------------------- Test End Timestamp ----------------------");
-        system("date");
-        system("echo ----------------------------------------------------------------; echo");
+        rc2 = system("echo;echo ---------------------- Test End Timestamp ----------------------");
+        rc2 = system("date");
+        rc2 = system("echo ----------------------------------------------------------------; echo");
+	if ( rc2 ) 
+		printf("system() error \n");
     }
 
     return rc;

--- a/src/cflash/test/cflash_test_ioctl_io.c
+++ b/src/cflash/test/cflash_test_ioctl_io.c
@@ -859,7 +859,7 @@ int max_ctx_rcvr_except_last_one()
 {
     int max_p = MAX_OPENS;
     int i;
-    int rc;
+    int rc, rc2;
     bool do_recover = true;
     int msgid;
     struct mymsgbuf msg_buf;
@@ -868,7 +868,7 @@ int max_ctx_rcvr_except_last_one()
     char cmdToRun[MAXBUFF];
     const char *configCmdP = "echo 10000000  > /sys/kernel/debug/powerpc/eeh_max_freezes";
 #endif
-    system("ipcrm -Q 0x1234 >/dev/null 2>&1");
+    rc = system("ipcrm -Q 0x1234 >/dev/null 2>&1");
 
     for (i = 0; i < max_p-1; i++)
     {
@@ -954,7 +954,9 @@ int max_ctx_rcvr_except_last_one()
     }
     rc = wait4all();
     printf("%d: rc for wait4all(): %d\n", getpid(), rc);
-    system("ipcrm -Q 0x1234");
+    rc2 = system("ipcrm -Q 0x1234");
+    if ( rc2 )
+        printf("%d: rc for system(\"ipcrm -Q 0x1234\"): %d\n", getpid(), rc);
     return rc;
 }
 

--- a/src/cflash/test/cflash_test_util.c
+++ b/src/cflash/test/cflash_test_util.c
@@ -1500,11 +1500,11 @@ int send_rw_lsize(struct ctx *p_ctx, struct rwlargebuf *p_rwb,
                    buf_len))
         {
             sprintf(buf,"read.%d",pid);
-            rfd = open(buf,O_RDWR|O_CREAT);
+            rfd = open(buf,O_RDWR,O_CREAT);
             sprintf(buf,"write.%d",pid);
-            wfd = open(buf,O_RDWR|O_CREAT);
-            write(rfd,p_rwb->rbuf[i],buf_len);
-            write(wfd,p_rwb->rbuf[i],buf_len);
+            wfd = open(buf,O_RDWR,O_CREAT);
+            rc = write(rfd,p_rwb->rbuf[i],buf_len);
+            rc = write(wfd,p_rwb->rbuf[i],buf_len);
             close(rfd);
             close(wfd);
             printf("%d: miscompare at start_lba 0X%"PRIX64"\n",
@@ -2492,7 +2492,7 @@ int get_flash_disks(struct flash_disk disks[], int type)
     debug("%d: Refer /tmp/flist file for sample format\n", pid);
 
 #ifndef _AIX
-    system("rm /tmp/flist_sameAdap /tmp/flist_diffAdap /tmp/flist_disk_shared >/dev/null 2>&1");
+    rc = system("rm /tmp/flist_sameAdap /tmp/flist_diffAdap /tmp/flist_disk_shared >/dev/null 2>&1");
 #endif
     if( exportFlag == 0)
     {
@@ -4473,6 +4473,7 @@ int ctx_init_reuse(struct ctx *p_ctx)
 void displayBuildinfo()
 {
     int i=0;
+    int rc=0;
     static int entrycounter=0;
     FILE *fptr;
     char buf[1024];
@@ -4484,16 +4485,18 @@ void displayBuildinfo()
     printf("Kernel Level:\n");
     printf("-------------------------------------------\n");
     fflush(stdout);
-    system("uname -a");
-    system("dpkg -l | grep -w `uname -a | awk '{print $3}'|cut -f2 -d-` | grep -i linux");
+    rc = system("uname -a");
+    if ( rc )
+	printf("Invalid uname -a output\n");
+    rc = system("dpkg -l | grep -w `uname -a | awk '{print $3}'|cut -f2 -d-` | grep -i linux");
     printf("\ncat /opt/ibm/capikv/version.txt:\n");
     printf("-------------------------------------------\n");
     fflush(stdout);
-    system("cat /opt/ibm/capikv/version.txt");
+    rc = system("cat /opt/ibm/capikv/version.txt");
     printf("\nAFU level:\n");
     printf("-------------------------------------------\n");
     fflush(stdout);
-    system("ls /dev/cxl/afu[0-9]*.0m > /tmp/afuF");
+    rc = system("ls /dev/cxl/afu[0-9]*.0m > /tmp/afuF");
 
     fptr = fopen("/tmp/afuF", "r");
     while (fgets(buf,1024, fptr) != NULL)
@@ -4510,12 +4513,12 @@ void displayBuildinfo()
         }
 
         sprintf(cmd, "/opt/ibm/capikv/afu/cxl_afu_dump %s | grep Version", buf);
-        system(cmd);
+        rc = system(cmd);
     }
     fclose(fptr);
     printf("-------------------------------------------\n");
     fflush(stdout);
-    system("update_flash -d");
+    rc = system("update_flash -d");
     printf("-------------------------------------------\n\n");
     fflush(stdout);
 }

--- a/src/kv/test/fvt_kv_tst_errors.C
+++ b/src/kv/test/fvt_kv_tst_errors.C
@@ -53,7 +53,7 @@ int32_t  async_err = 0;
 void kv_tst_io_errors_cb(int errcode, uint64_t dt, int64_t res)
 {
     --async_io;
-    if (async_err != errcode) printf("tag=%"PRIx64"\n", dt);
+    if (async_err != errcode) printf("tag=%" PRIx64"\n", dt);
     ASSERT_EQ(async_err, errcode);
 }
 

--- a/src/kv/test/fvt_kv_utils_async_cb.C
+++ b/src/kv/test/fvt_kv_utils_async_cb.C
@@ -138,12 +138,12 @@ static void kv_async_cb(int errcode, uint64_t dt, int64_t res)
     }
     if (pCB->b_mark != B_MARK)
     {
-        KV_TRC_FFDC(pFT, "FFDC: B_MARK FAILURE %p: %"PRIx64"", pCB, pCB->b_mark);
+        KV_TRC_FFDC(pFT, "FFDC: B_MARK FAILURE %p: %" PRIx64"", pCB, pCB->b_mark);
         return;
     }
     if (pCB->e_mark != E_MARK)
     {
-        KV_TRC_FFDC(pFT, "FFDC: E_MARK FAILURE %p: %"PRIx64"", pCB, pCB->e_mark);
+        KV_TRC_FFDC(pFT, "FFDC: E_MARK FAILURE %p: %" PRIx64"", pCB, pCB->e_mark);
         return;
     }
     if (EBUSY == errcode) {kv_async_q_retry(pCB); goto done;}
@@ -312,7 +312,7 @@ static void kv_async_SET_KEY(async_CB_t *pCB)
     uint64_t tag = (uint64_t)pCB;
     int32_t  rc  = 0;
 
-    KV_TRC_IO(pFT, "SET_KEY: %p, %p %"PRIx64" %d", pCB, pCB->db, tag, pCB->len_i);
+    KV_TRC_IO(pFT, "SET_KEY: %p, %p %" PRIx64" %d", pCB, pCB->db, tag, pCB->len_i);
 
     pCB->tag = tag;
 
@@ -611,7 +611,7 @@ void kv_async_job_perf(uint32_t jobs, uint32_t klen, uint32_t vlen,uint32_t len)
 
     /* do writes */
     (void)ark_stats(kv_async_get_ark(ASYNC_SINGLE_CONTEXT), &ops, &ios);
-    KV_TRC(pFT, "PERF wr: ops:%"PRIu64" ios:%"PRIu64"", ops, ios);
+    KV_TRC(pFT, "PERF wr: ops:%" PRIu64" ios:%" PRIu64"", ops, ios);
     gettimeofday(&start, NULL);
     kv_async_run_jobs();        /* run write jobs */
     KV_TRC(pFT, "writes done");
@@ -619,7 +619,7 @@ void kv_async_job_perf(uint32_t jobs, uint32_t klen, uint32_t vlen,uint32_t len)
     wr_us += (stop.tv_sec*mil  + stop.tv_usec) -
              (start.tv_sec*mil + start.tv_usec);
     (void)ark_stats(kv_async_get_ark(ASYNC_SINGLE_CONTEXT),&post_ops,&post_ios);
-    KV_TRC(pFT, "PERF wr: ops:%"PRIu64" ios:%"PRIu64"", post_ops, post_ios);
+    KV_TRC(pFT, "PERF wr: ops:%" PRIu64" ios:%" PRIu64"", post_ops, post_ios);
     wr_ops += post_ops - ops;
     wr_ios += post_ios - ios;
 
@@ -643,7 +643,7 @@ void kv_async_job_perf(uint32_t jobs, uint32_t klen, uint32_t vlen,uint32_t len)
     pCTs->flags |= KV_ASYNC_CT_RUNNING;
 
     (void)ark_stats(kv_async_get_ark(0), &ops, &ios);
-    KV_TRC(pFT, "PERF rd: ops:%"PRIu64" ios:%"PRIu64"", ops, ios);
+    KV_TRC(pFT, "PERF rd: ops:%" PRIu64" ios:%" PRIu64"", ops, ios);
     gettimeofday(&start, NULL);
     kv_async_run_jobs();        /* run read jobs */
     gettimeofday(&stop, NULL);
@@ -651,7 +651,7 @@ void kv_async_job_perf(uint32_t jobs, uint32_t klen, uint32_t vlen,uint32_t len)
     rd_us += (stop.tv_sec*mil  + stop.tv_usec) -
              (start.tv_sec*mil + start.tv_usec);
     (void)ark_stats(kv_async_get_ark(0), &post_ops, &post_ios);
-    KV_TRC(pFT, "PERF rd: ops:%"PRIu64" ios:%"PRIu64"", post_ops, post_ios);
+    KV_TRC(pFT, "PERF rd: ops:%" PRIu64" ios:%" PRIu64"", post_ops, post_ios);
     rd_ops += post_ops - ops;
     rd_ios += post_ios - ios;
 
@@ -1167,7 +1167,7 @@ void kv_async_run_jobs(void)
         (void)ark_stats(pCTs[i].ark, &ops, &ios);
         tops += (uint32_t)ops;
         tios += (uint32_t)ios;
-        KV_TRC(pFT, "PERF ark%p ops:%"PRIu64" ios:%"PRIu64"", pCTs[i].ark, ops, ios);
+        KV_TRC(pFT, "PERF ark%p ops:%" PRIu64" ios:%" PRIu64"", pCTs[i].ark, ops, ios);
 
         EXPECT_EQ(0, ark_delete(pCTs[i].ark));
     }

--- a/src/test/framework/gtest.objtests.mk
+++ b/src/test/framework/gtest.objtests.mk
@@ -16,7 +16,9 @@
 
 # Points to the root of Google Test, relative to where this file is.
 # Remember to tweak this if you move this file.
+ifeq ($GTEST_DIR,)
 GTEST_DIR =$(ROOTPATH)/src/test/framework/googletest/googletest
+endif
 
 UNAME=$(shell uname)
 

--- a/src/test/pvtestauto.c
+++ b/src/test/pvtestauto.c
@@ -830,7 +830,7 @@ void *run_pvthread_loop(void *data)
                      */
 
                     fd = open ("/dev/urandom", O_RDONLY);
-                    read (fd, comp_data_buf, BUFSIZE);
+                    rc = read (fd, comp_data_buf, BUFSIZE);
                     close (fd);
 
                     rc = cblk_write(pvt_data->chunk_id,comp_data_buf,lba,num_blocks,0);
@@ -905,7 +905,7 @@ void *run_pvthread_loop(void *data)
                      */
 
                     fd = open ("/dev/urandom", O_RDONLY);
-                    read (fd, comp_data_buf, BUFSIZE);
+                    rc = read (fd, comp_data_buf, BUFSIZE);
                     close (fd);
 
                     rc = cblk_awrite(pvt_data->chunk_id,comp_data_buf,lba,num_blocks,&wtag,NULL,0);

--- a/src/test/xlate.c
+++ b/src/test/xlate.c
@@ -577,7 +577,7 @@ void send_readm(struct ctx *p_ctx, __u64 start_lba, __u64 stride) {
 
 // compare wbuf & rbuf
 void rw_cmp_buf(struct ctx *p_ctx, __u64 start_lba, __u64 stride) {
-    int i;
+    int i, rc;
     char buf[32];
     int read_fd, write_fd, readm_fd;
 
@@ -591,15 +591,17 @@ void rw_cmp_buf(struct ctx *p_ctx, __u64 start_lba, __u64 stride) {
 	    send_readm(p_ctx, start_lba, stride); // sends NUM_CMDS reads
 
 	    sprintf(buf, "read.%d", pr_id);
-	    read_fd = open(buf, O_RDWR|O_CREAT);
+	    read_fd = open(buf, O_RDWR,O_CREAT);
 	    sprintf(buf, "write.%d", pr_id);
-	    write_fd = open(buf, O_RDWR|O_CREAT);
+	    write_fd = open(buf, O_RDWR,O_CREAT);
 	    sprintf(buf, "readm.%d", pr_id);
-	    readm_fd = open(buf, O_RDWR|O_CREAT);
+	    readm_fd = open(buf, O_RDWR,O_CREAT);
 
-	    write(read_fd,  &p_ctx->rbuf[i][0], sizeof(p_ctx->rbuf[i]));
-	    write(write_fd, &p_ctx->wbuf[i][0], sizeof(p_ctx->wbuf[i]));
-	    write(readm_fd, &p_ctx->rbufm[i][0], sizeof(p_ctx->rbufm[i]));
+	    rc = write(read_fd,  &p_ctx->rbuf[i][0], sizeof(p_ctx->rbuf[i]));
+	    rc = write(write_fd, &p_ctx->wbuf[i][0], sizeof(p_ctx->wbuf[i]));
+	    rc = write(readm_fd, &p_ctx->rbufm[i][0], sizeof(p_ctx->rbufm[i]));
+	    if ( rc != 0 )
+	    	printf("%d: write error on readm \n",rc);
 
 	    close(read_fd);
 	    close(write_fd);
@@ -721,14 +723,14 @@ main(int argc, char *argv[])
 #else
     sprintf(ctx_file, "ctx.%d", pr_id);
     unlink(ctx_file);
-    ctx_fd = open(ctx_file, O_RDWR|O_CREAT);
+    ctx_fd = open(ctx_file, O_RDWR,O_CREAT);
     if (ctx_fd < 0) {
 	fprintf(stderr, "open failed: file %s, errno %d", ctx_file, errno);
 	exit(-1);
     }
 
     // mmap a struct ctx 
-    ftruncate(ctx_fd, sizeof(struct ctx));
+    rc = ftruncate(ctx_fd, sizeof(struct ctx));
     map = mmap(NULL, sizeof(struct ctx),
 	       PROT_READ|PROT_WRITE, MAP_SHARED, ctx_fd, 0);
     if (map == MAP_FAILED) {


### PR DESCRIPTION
 Update makefile to define default
 Prevent compilation errors when syscalls() return code not tested

Signed-off-by: Thierry Fauck <tfauck@free.fr>

	modified:   config.linux.mk
	modified:   config.mk
	modified:   src/block/test/blk_api_tst.c
	modified:   src/block/test/fvt_block.C
	modified:   src/cflash/test/174.c
	modified:   src/cflash/test/cflash_test2.c
	modified:   src/cflash/test/cflash_test_engine.c
	modified:   src/cflash/test/cflash_test_ioctl_io.c
	modified:   src/cflash/test/cflash_test_util.c
	modified:   src/kv/test/fvt_kv_tst_errors.C
	modified:   src/kv/test/fvt_kv_utils_async_cb.C
	modified:   src/test/framework/gtest.objtests.mk
	modified:   src/test/pvtestauto.c
	modified:   src/test/xlate.c

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/capiflash/7)
<!-- Reviewable:end -->
