### PR TITLE
Changes on debian/control file

### DIFF
--- a/src/build/debian/control
+++ b/src/build/debian/control
@@ -3,7 +3,7 @@ Maintainer: IBM Corp. <mpvageli@us.ibm.com>
 Uploaders:  Mike Vageline <mpvageli@us.ibm.com>
 Section: utils
 Priority: extra
-Standards-Version: 3.9.8
+Standards-Version: 4.0.0
 Build-Depends: debhelper (>=9), doxygen, libudev1, libudev-dev,
                gcc-5, g++-5, lsb-release
 Homepage: https://github.com/open-power
@@ -11,7 +11,7 @@ Vcs-Git: https://github.com/open-power/cxlflash.git
 
 Package: cxlflash
 Architecture: ppc64 ppc64el
-Depends: ${shlibs:Depends}, libudev-dev, cxlflash (= ${binary:Version})
+Depends: ${shlibs:Depends}, libudev-dev, ${misc:Depends}
 Conflicts: ibmcapikv
 Replaces: ibmcapikv
 Description: IBM Data Engine for NoSQL Software Libraries : cxlflash
@@ -30,7 +30,7 @@ Description: IBM Data Engine for NoSQL Software Libraries : cxlflash
 
 Package: cxlflashimage
 Architecture: ppc64 ppc64el
-Depends: cxlflash (= ${binary:Version}), ${shlibs:Depends}
+Depends: cxlflash (= ${binary:Version}), ${shlibs:Depends}, ${misc:Depends}
 Conflicts: afuimage
 Replaces: afuimage
 Description: IBM Data Engine for NoSQL Software Libraries : cxlflash afu library

--- a/src/build/debian/rules
+++ b/src/build/debian/rules
@@ -69,13 +69,13 @@ override_dh_installdeb:
 override_dh_auto_test:
 override_dh_testroot:
 override_dh_installman:
-override_dh_fixperms:
-override_dh_md5sums:
-	echo "Skipping $@"
+#override_dh_fixperms:
+#override_dh_md5sums:
+#	echo "Skipping $@"
 
 override_dh_gencontrol:
 	dpkg-gencontrol -pcxlflash -ldebian/changelog -Tdebian/cxlflash.substvars -Pdebian/cxlflash
 	dpkg-gencontrol -pcxlflashimage -ldebian/changelog -Tdebian/cxlflashimage.substvars -Pdebian/cxlflashimage
 
 override_dh_shlibdeps:
-	dh_shlibdeps -l$(PWD)/img
+	dh_shlibdeps -l$(CURDIR)/img


### PR DESCRIPTION
Changes were made in debian/control file in order to fix some lintian
errors/warnings:

 1. 'cxlflash (= ${binary:Version})' was removed from "Depends" field, in
order to fix the "package-depends-on-itself" warning.

 2. Standards-Version was updated from 3.9.8 to 4.0.0, since the package is
following the policy version. It fixes the
"out-of-date-standards-version" warning.

 3. '${misc:Depends}' was added to "Depends" field of both cxlflash and
cxlflashimage. It is necessary because the source package uses
debhelper. Fixes the "debhelper-but-no-misc-depends" warning.

Signed-off-by: Rodrigo R. Galvao <rosattig@br.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/capiflash/11)
<!-- Reviewable:end -->
