### PR TITLE
Fix lintian warnings related with scripts

### DIFF
--- a/src/build/install/makefile
+++ b/src/build/install/makefile
@@ -169,7 +169,7 @@ endif
 	${INSTALL} -s ${_TESTSRCDIR}/run_kv_benchmark ${_BIN_DIR}
 	${INSTALL} -s ${_TESTSRCDIR}/kv_perf ${_BIN_DIR}
 	${INSTALL}    ${ROOTPATH}/src/test/ioppt.pl ${_BIN_DIR}
-	${INSTALL}    ${ROOTPATH}/src/test/ioppts.qd ${_BIN_DIR}
+	${INSTALL} -m 644 ${ROOTPATH}/src/test/ioppts.qd ${_BIN_DIR}
 
 	${INSTALL} ${_RESOURCEDIR}/cflash_plinks ${_BIN_DIR}
 	${INSTALL} ${_RESOURCEDIR}/cflash_getslot ${_BIN_DIR}
@@ -193,17 +193,17 @@ endif
 	${INSTALL} -m 644 ${_RESOURCEDIR}/80-cxlflash.rules ${_UDEV_RULES_DIR}
 
 	@if [[ -e ${ROOTPATH}/src/build/version.txt ]]; then \
-       echo "${INSTALL} ${ROOTPATH}/src/build/version.txt ${INSTALL_ROOT}"; \
-       ${INSTALL} ${ROOTPATH}/src/build/version.txt ${INSTALL_ROOT}; \
+       echo "${INSTALL} -m 644 ${ROOTPATH}/src/build/version.txt ${INSTALL_ROOT}"; \
+       ${INSTALL} -m 644 ${ROOTPATH}/src/build/version.txt ${INSTALL_ROOT}; \
      else \
-       echo "${INSTALL} ${_TESTSRCDIR}/version.txt ${INSTALL_ROOT}"; \
-       ${INSTALL} ${_TESTSRCDIR}/version.txt ${INSTALL_ROOT}; \
+       echo "${INSTALL} -m 644${_TESTSRCDIR}/version.txt ${INSTALL_ROOT}"; \
+       ${INSTALL} -m 644 ${_TESTSRCDIR}/version.txt ${INSTALL_ROOT}; \
      fi
-	${INSTALL} ${_RESOURCEDIR}/afu_versions ${_ETC_DIR}
+	${INSTALL} -m 644 ${_RESOURCEDIR}/afu_versions ${_ETC_DIR}
 	${INSTALL} ${_RESOURCEDIR}/cflash_configure ${PKGDIR}
 	${INSTALL} ${_RESOURCEDIR}/cflash_configure ${_ETC_DIR}
-	${INSTALL} ${_RESOURCEDIR}/cxlffdc.debug ${_ETC_DIR}
-	${INSTALL} ${_RESOURCEDIR}/cxlffdc.cleardebug ${_ETC_DIR}
+	${INSTALL} -m 644 ${_RESOURCEDIR}/cxlffdc.debug ${_ETC_DIR}
+	${INSTALL} -m 644 ${_RESOURCEDIR}/cxlffdc.cleardebug ${_ETC_DIR}
 endif
 	
 	@#Libs
@@ -310,8 +310,8 @@ ${FW_FILES}:
 ifneq ($(TARGET_PLATFORM),x86_64)
 	@mkdir -p ${_AFU_IMAGES_DIR}
 	@if [[ -e ${_RESOURCEDIR}/$@ ]]; then \
-         echo ${INSTALL} ${_RESOURCEDIR}/$@ ${_AFU_IMAGES_DIR}; \
-              ${INSTALL} ${_RESOURCEDIR}/$@ ${_AFU_IMAGES_DIR}; \
+         echo ${INSTALL} -m 644 ${_RESOURCEDIR}/$@ ${_AFU_IMAGES_DIR}; \
+              ${INSTALL} -m 644 ${_RESOURCEDIR}/$@ ${_AFU_IMAGES_DIR}; \
          if [[ $@ =~ gz ]]; then gunzip ${_AFU_IMAGES_DIR}/$@; fi; \
      fi
 ifneq ($(UNAME),AIX)
@@ -328,7 +328,7 @@ cflashimage: ${FW_FILES}
 ifneq ($(UNAME),AIX)
 ifneq ($(TARGET_PLATFORM),x86_64)
 	${INSTALL} ${_AFUDIR}/surelock_vpd2rbf.pl ${AFU_ROOT}
-	${INSTALL} ${_AFUDIR}/vpd_FlashGT.csv ${AFU_ROOT}
+	${INSTALL} -m 644 ${_AFUDIR}/vpd_FlashGT.csv ${AFU_ROOT}
 	${INSTALL} -s ${_TESTSRCDIR}/cxl_afu_dump ${AFU_ROOT}
 	${INSTALL} -s ${_TESTSRCDIR}/cxl_afu_status ${AFU_ROOT}
 	${INSTALL} -s ${_TESTSRCDIR}/flashgt_temp ${AFU_ROOT}
@@ -344,14 +344,14 @@ ifneq ($(TARGET_PLATFORM),x86_64)
 	${INSTALL} ${_RESOURCEDIR}/cflash_stick.pl ${AFU_ROOT}
 	${INSTALL} ${_RESOURCEDIR}/cflash_perfcheck.pl ${AFU_ROOT}
 	${INSTALL} ${_RESOURCEDIR}/cflash_mfg_init.pl ${AFU_ROOT}
-	${INSTALL} ${_RESOURCEDIR}/blacklist-cxlflash.conf ${AFU_ROOT}
+	${INSTALL} -m 644 ${_RESOURCEDIR}/blacklist-cxlflash.conf ${AFU_ROOT}
 	${INSTALL} ${_RESOURCEDIR}/flash_all_adapters ${AFU_ROOT}
 	${INSTALL} ${_RESOURCEDIR}/reload_all_adapters ${AFU_ROOT}
 	${INSTALL} ${_RESOURCEDIR}/psl_trace_dump ${AFU_ROOT}
 	${INSTALL} ${_RESOURCEDIR}/cxl_flash_vm ${AFU_ROOT}
 	${INSTALL} ${_RESOURCEDIR}/cxl_afu_fmt_unit ${AFU_ROOT}
 	${INSTALL} ${_RESOURCEDIR}/flashgt_nvme_nsq ${AFU_ROOT}
-	${INSTALL} ${_RESOURCEDIR}/afu_versions ${_AFU_IMAGES_DIR}/.remove
+	${INSTALL} -m 644 ${_RESOURCEDIR}/afu_versions ${_AFU_IMAGES_DIR}/.remove
 endif
 endif
 

--- a/src/build/install/makefile
+++ b/src/build/install/makefile
@@ -169,7 +169,7 @@ endif
 	${INSTALL} -s ${_TESTSRCDIR}/run_kv_benchmark ${_BIN_DIR}
 	${INSTALL} -s ${_TESTSRCDIR}/kv_perf ${_BIN_DIR}
 	${INSTALL}    ${ROOTPATH}/src/test/ioppt.pl ${_BIN_DIR}
-	${INSTALL} -m 644 ${ROOTPATH}/src/test/ioppts.qd ${_BIN_DIR}
+	${INSTALL}    ${ROOTPATH}/src/test/ioppts.qd ${_BIN_DIR}
 
 	${INSTALL} ${_RESOURCEDIR}/cflash_plinks ${_BIN_DIR}
 	${INSTALL} ${_RESOURCEDIR}/cflash_getslot ${_BIN_DIR}
@@ -202,8 +202,8 @@ endif
 	${INSTALL} -m 644 ${_RESOURCEDIR}/afu_versions ${_ETC_DIR}
 	${INSTALL} ${_RESOURCEDIR}/cflash_configure ${PKGDIR}
 	${INSTALL} ${_RESOURCEDIR}/cflash_configure ${_ETC_DIR}
-	${INSTALL} -m 644 ${_RESOURCEDIR}/cxlffdc.debug ${_ETC_DIR}
-	${INSTALL} -m 644 ${_RESOURCEDIR}/cxlffdc.cleardebug ${_ETC_DIR}
+	${INSTALL} ${_RESOURCEDIR}/cxlffdc.debug ${_ETC_DIR}
+	${INSTALL} ${_RESOURCEDIR}/cxlffdc.cleardebug ${_ETC_DIR}
 endif
 	
 	@#Libs

--- a/src/build/install/resources/cxlfd.service
+++ b/src/build/install/resources/cxlfd.service
@@ -1,4 +1,3 @@
-#!/bin/bash -e
 #  IBM_PROLOG_BEGIN_TAG
 #  This is an automatically generated prolog.
 #

--- a/src/build/install/resources/cxlffdc.cleardebug
+++ b/src/build/install/resources/cxlffdc.cleardebug
@@ -1,3 +1,4 @@
+#!/bin/bash
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/src/build/install/resources/cxlffdc.debug
+++ b/src/build/install/resources/cxlffdc.debug
@@ -1,3 +1,4 @@
+#!/bin/bash
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/src/build/install/resources/postinstall
+++ b/src/build/install/resources/postinstall
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/src/build/install/resources/postremove
+++ b/src/build/install/resources/postremove
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #

--- a/src/test/ioppts.qd
+++ b/src/test/ioppts.qd
@@ -1,3 +1,4 @@
+#!/bin/bash
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #


### PR DESCRIPTION
Some lintian warnings were fixed:

1. maintainer-script-ignores-errors
        postinstall and postremove scripts were being executed without
the "-e" flag.

2. script-not-executable
        cxlfd.service should not have a bash script line (shebang) in
the first line.

3. executable-not-elf-or-script
        Some files are not supposed to have execute permission, e.g.
version.txt, vpd_FlashGT.csv, ioppts.qd, etc..
        That's why those files are now being installed with permission
mode of 644.

Signed-off-by: Rodrigo R. Galvao <rosattig@br.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/capiflash/12)
<!-- Reviewable:end -->
