### PR TITLE
Fix error in create_tarball script

### DIFF
--- a/src/build/tools/create_tarball
+++ b/src/build/tools/create_tarball
@@ -48,7 +48,8 @@ cp * ${BDIR}/$pkg 2>/dev/null
 if [[ -e ${BDIR}/$pkg/customrc ]]; then rm -f ${BDIR}/$pkg/customrc; fi
 cp customrc.p8elblkkermc ${BDIR}/$pkg/customrc
 cp -R src ${BDIR}/$pkg
-cp obj/tests/version.txt ${BDIR}/$pkg/src/build
+if [[ -e obj/tests/version.txt ]]; then cp obj/tests/version.txt ${BDIR}/$pkg/src/build; fi
+if [[ -e src/build/version.txt ]]; then cp src/build/version.txt ${BDIR}/$pkg/src/build; fi
 find ${BDIR}/$pkg -name "*.bak" -exec rm {} \;
 find ${BDIR}/$pkg -name "*.save" -exec rm {} \;
 


### PR DESCRIPTION
Fix the message 'cp: cannot stat 'obj/tests/version.txt': No such file
or directory' when trying to run the create_tarball script.

Signed-off-by: Rodrigo R. Galvao <rosattig@br.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/capiflash/15)
<!-- Reviewable:end -->
