### PR TITLE
Fix warning about script without set -e

### DIFF
--- a/src/build/install/resources/postafuinstall
+++ b/src/build/install/resources/postafuinstall
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
@@ -24,6 +24,7 @@
 #
 # IBM_PROLOG_END_TAG
 
+set -e
 USERNAME=cxl
 GROUPNAME=$USERNAME
 

--- a/src/build/install/resources/postinstall
+++ b/src/build/install/resources/postinstall
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
@@ -24,7 +24,7 @@
 #
 # IBM_PROLOG_END_TAG
 
-
+set -e
 USERNAME=cxl
 GROUPNAME=$USERNAME
 BIN_DIR=/usr/bin

--- a/src/build/install/resources/preafuremove
+++ b/src/build/install/resources/preafuremove
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
@@ -24,6 +24,7 @@
 #
 # IBM_PROLOG_END_TAG
 
+set -e
 BIN_DIR=/usr/bin
 LFW_DIR=/lib/firmware/cxlflash
 for f in $(cat ${LFW_DIR}/.remove|awk '{print $2}')

--- a/src/build/install/resources/preremove
+++ b/src/build/install/resources/preremove
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/bin/bash
 # IBM_PROLOG_BEGIN_TAG
 # This is an automatically generated prolog.
 #
@@ -24,6 +24,7 @@
 #
 # IBM_PROLOG_END_TAG
 
+set -e
 BIN_DIR=/usr/bin
 EXT_DIR=/usr/lib/cxlflash/ext
 CRON_FILE=/etc/cron.hourly/cflash_logs_cron


### PR DESCRIPTION
Fix the 'maintainer-script-without-set-e' warning.

Signed-off-by: Rodrigo R. Galvao <rosattig@br.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/capiflash/16)
<!-- Reviewable:end -->
