### PR TITLE
Override hardening-no-fortify

### DIFF
--- a/src/build/debian/lintian-overrides
+++ b/src/build/debian/lintian-overrides
@@ -1,3 +1,7 @@
 # -there are multiple libraries installed with the cxlflash package
 # -cxlflash supports multiple adapters
 cxlflash: package-name-doesnt-match-sonames
+
+# false-positives
+cxlflash binary: hardening-no-fortify-functions
+cxlflashimage binary: hardening-no-fortify-functions usr/bin/flashgt_vpd_access

--- a/src/build/debian/rules
+++ b/src/build/debian/rules
@@ -70,7 +70,7 @@ override_dh_installdeb:
 
 override_dh_auto_test:
 override_dh_testroot:
-override_dh_installman:
+#override_dh_installman:
 #override_dh_fixperms:
 #override_dh_md5sums:
 #override_dh_makeshlibs:


### PR DESCRIPTION
Override hardening-no-fortify in debian/lintian-overrides and comment
the 'override_dh_installman' so as to install the man pages in the build
package directory.

Signed-off-by: Rodrigo R. Galvao <rosattig@br.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/capiflash/17)
<!-- Reviewable:end -->
