### PR TITLE
Fix watch file

### DIFF
--- a/src/build/debian/watch
+++ b/src/build/debian/watch
@@ -1,6 +1,2 @@
-# Currently there is a version to be uploaded through 
-# https://github.com/open-power/capiflash/archive/master.zip
-# but this is not a tar file and it seems not up-to-date with
-# upstream master release maintained by git.
-version=3
-https://github.com/open-power/capiflash/archive/master.zip
+version=4
+https://github.com/open-power/capiflash/tags (?:.*?/)?v?(\d[\d.]*)\.tar\.gz


### PR DESCRIPTION
The watch file was fixed in order to work with the uscan command. Now,
it's just needed to create a tag with the current version,
e.g. v4.3.2493, pointing to the last commit.

Signed-off-by: Rodrigo R. Galvao <rosattig@br.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/capiflash/18)
<!-- Reviewable:end -->
