### PR TITLE
Fix initial issues pointed on RFS

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,10 +1,10 @@
 Source: cxlflash
 Maintainer: IBM Corp. <mpvageli@us.ibm.com>
-Uploaders:  Mike Vageline <mpvageli@us.ibm.com>
+Uploaders: Rodrigo R. Galvao <rosattig@br.ibm.com>
 Section: utils
 Priority: extra
-Standards-Version: 4.0.0
-Build-Depends: debhelper (>=9), doxygen, libudev1, libudev-dev,
+Standards-Version: 4.0.1
+Build-Depends: debhelper (>=10), doxygen, libudev1, libudev-dev,
                gcc-5, g++-5, lsb-release, libcxl1, libcxl-dev, help2man
 Homepage: https://github.com/open-power
 Vcs-Git: https://github.com/open-power/cxlflash.git

--- a/debian/rules
+++ b/debian/rules
@@ -2,8 +2,8 @@
 # See debhelper(7) (uncomment to enable)
 # output every command that modifies files on the build system.
 # Uncomment this to turn on verbose mode.
-export DH_VERBOSE=1
-export DH_OPTIONS=-v
+#export DH_VERBOSE=1
+#export DH_OPTIONS=-v
 
 # see FEATURE AREAS in dpkg-buildflags(1)
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all
@@ -74,12 +74,6 @@ override_dh_installdeb:
 	echo 'activate-noawait ldconfig' > debian/cxlflash/DEBIAN/triggers
 
 override_dh_auto_test:
-override_dh_testroot:
-#override_dh_installman:
-#override_dh_fixperms:
-#override_dh_md5sums:
-#override_dh_makeshlibs:
-	echo "Skipping $@"
 
 override_dh_gencontrol:
 	dpkg-gencontrol -pcxlflash      -ldebian/changelog -Tdebian/cxlflash.substvars -Pdebian/cxlflash

--- a/debian/source/include-binaries
+++ b/debian/source/include-binaries
@@ -1,6 +1,3 @@
-pkg/afu_root/usr/bin/cxl_afu_dump
-pkg/afu_root/usr/bin/cxl_afu_status
-pkg/afu_root/usr/bin/flashgt_temp
 pkg/afu_root/usr/bin/flashgt_vpd_access
 pkg/install_root/usr/bin/blockio
 pkg/install_root/usr/bin/blocklistio


### PR DESCRIPTION
RFS message:
https://bugs.debian.org/cgi-bin/bugreport.cgi?att=0;bug=870909;msg=31

Some of the issues that were fixed:
1. debian/control
        - change Uploader name/email, since mpvageli@us.ibm.com email
          was also used in the Maintainer field
        - Upgrade Standards-Version to the latest: 4.0.1
        - Use debhelper level 10
2. debian/rules
        - comment DH_VERBOSE=1 and DH_OPTIONS=-v
        - remove the commented override lines
        - remove override_dh_testroot
3. debian/source/include-binaries
        - exclude the binaries that are no longer being included:
        cxl_afu_dump, cxl_afu_status and flashgt_temp

Signed-off-by: Rodrigo R. Galvao <rosattig@br.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/capiflash/20)
<!-- Reviewable:end -->
