### PR TITLE
Override hardening warnings

### DIFF
--- a/debian/lintian-overrides
+++ b/debian/lintian-overrides
@@ -3,4 +3,6 @@
 cxlflash: package-name-doesnt-match-sonames
 
 # false-positives
-cxlflash binary: hardening-no-fortify-functions usr/bin/flashgt_vpd_access
+cxlflash binary: hardening-no-fortify-functions 
+cxlflash binary: hardening-no-pie
+cxlflash binary: hardening-no-bindnow


### PR DESCRIPTION
Lintian showed some hardening warnings which are considered
false-positives, so I put these warnings in the debian/lintian-overrides
file.

Signed-off-by: Rodrigo R. Galvao <rosattig@br.ibm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/capiflash/22)
<!-- Reviewable:end -->
