### PR TITLE
Remove fortify from lintian-overrides

### DIFF
--- a/debian/lintian-overrides
+++ b/debian/lintian-overrides
@@ -2,5 +2,3 @@
 # -cxlflash supports multiple adapters
 cxlflash: package-name-doesnt-match-sonames
 
-# false-positives
-cxlflash binary: hardening-no-fortify-functions usr/bin/flashgt_vpd_access


### PR DESCRIPTION
The fortify warning was removed from debian/lintian-overrides file,
since it's not an issue anymore and lintian does not complain about it.

Signed-off-by: Rodrigo R. Galvao <rodrigorosattig@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/open-power/capiflash/23)
<!-- Reviewable:end -->
